### PR TITLE
fix: remove email redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ npm install @cdssnc/sanitize-pii
 import { sanitizePii, PiiSanitizer } from '@cdssnc/sanitize-pii';
 
 // Simple usage with default patterns
-const text = "Contact me at john@example.com or call (555) 123-4567 with Account ID 1234";
+const text = "Contact me at (555) 123-4567 with Account ID 1234";
 const sanitized = sanitizePii(text);
 console.log(sanitized);
-// Output: "Contact me at [Redacted: email] or call [Redacted: phone_number] with Account ID 1234"
+// Output: "Contact me at [Redacted: phone_number] with Account ID 1234"
 
 // Sanitizer with custom replacement template and pattern
 const sanitizer = new PiiSanitizer({
@@ -32,7 +32,7 @@ const sanitizer = new PiiSanitizer({
 
 const result = sanitizer.sanitize(text);
 console.log(result);
-// Output: "Contact me at ***email*** or call ***phone_number*** with ***account_id***"
+// Output: "Contact me at ***phone_number*** with ***account_id***"
 ```
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/sanitize-pii",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "TypeScript module for removing personally identifiable information (PII) from text",

--- a/src/__tests__/patterns.test.ts
+++ b/src/__tests__/patterns.test.ts
@@ -1,38 +1,6 @@
 import { defaultPatterns } from '../patterns';
 
 describe('Default Patterns', () => {
-  describe('email pattern', () => {
-    const emailPattern = defaultPatterns.find(p => p.name === 'email')!;
-
-    it('should match valid email addresses', () => {
-      const validEmails = [
-        'test@example.com',
-        'user.name@domain.co.uk',
-        'first+last@subdomain.example.org',
-        'user123@test-domain.com',
-      ];
-
-      validEmails.forEach(email => {
-        expect(emailPattern.regex.test(email)).toBe(true);
-        emailPattern.regex.lastIndex = 0; // Reset for global regex
-      });
-    });
-
-    it('should not match invalid email addresses', () => {
-      const invalidEmails = [
-        'notanemail',
-        '@domain.com',
-        'user@',
-        'user@domain',
-      ];
-
-      invalidEmails.forEach(email => {
-        expect(emailPattern.regex.test(email)).toBe(false);
-        emailPattern.regex.lastIndex = 0;
-      });
-    });
-  });
-
   describe('phone_number pattern', () => {
     const phonePattern = defaultPatterns.find(p => p.name === 'phone_number')!;
 

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -8,11 +8,6 @@ export const defaultPatterns: PiiPattern[] = [
     description: 'Address',
   },
   {
-    name: 'email',
-    regex: /\b[^@\s]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
-    description: 'Email address',
-  },
-  {
     name: 'canadian_passport',
     regex: /\b([A-Z]{2}[\s-]?\d{6})\b/g,
     description: 'Canadian passport',

--- a/tests/build/cjs.test.cjs
+++ b/tests/build/cjs.test.cjs
@@ -1,13 +1,10 @@
 const { sanitizePii, PiiSanitizer } = require('../../dist/cjs/index.js');
 
 const testText =
-  'My email is jane.smith@company.org and phone is (555) 987-6543';
+  'My phone number is (555) 987-6543';
 const result = sanitizePii(testText);
 
-if (
-  result.includes('jane.smith@company.org') ||
-  result.includes('(555) 987-6543')
-) {
+if (result.includes('(555) 987-6543')) {
   console.error('❌ CommonJS test failed: PII still visible in output');
   process.exit(1);
 }

--- a/tests/build/esm.test.mjs
+++ b/tests/build/esm.test.mjs
@@ -4,9 +4,9 @@ import {
   defaultPatterns,
 } from '../../dist/esm/index.js';
 
-const testText = 'My email is john.doe@example.com and SIN is 123-345-678';
+const testText = 'My address is 123 Fake St and SIN is 123-345-678';
 const result = sanitizePii(testText);
-if (result.includes('john.doe@example.com') || result.includes('123-345-678')) {
+if (result.includes('123 Fake St') || result.includes('123-345-678')) {
   console.error('❌ ESM test failed: PII still visible in output');
   process.exit(1);
 }
@@ -19,7 +19,7 @@ if (!classResult.includes('[Redacted:')) {
   process.exit(1);
 }
 
-const detected = sanitizer.detectPii('My email is test@example.com');
+const detected = sanitizer.detectPii('My address is 123 Fake St');
 if (detected.length === 0) {
   console.error('❌ ESM test failed: Pattern detection failed');
   process.exit(1);

--- a/tests/build/umd.test.mjs
+++ b/tests/build/umd.test.mjs
@@ -27,9 +27,9 @@ if (typeof window.sanitizePii !== 'function') {
   process.exit(1);
 }
 
-const testText = 'Contact: bob@test.com, Address: 123 Fake St';
+const testText = 'Contact: 123-456-7890, Address: 123 Fake St';
 const result = window.sanitizePii(testText);
-if (result.includes('bob@test.com') || result.includes('123 Fake St')) {
+if (result.includes('123-456-7890') || result.includes('123 Fake St')) {
   console.error('❌ UMD test failed: PII still visible in browser output');
   process.exit(1);
 }


### PR DESCRIPTION
# Summary
Forms has a use case where the email address is embedded in the message they are sanitizing.

The inclusion of the `email` pattern was based on the assumption that `<form>` elements would contain a separate email input field.

# Related
- https://github.com/cds-snc/platform-core-services/issues/781