### PR TITLE
fix: patterns not catching spaces as delimiters

### DIFF
--- a/src/__tests__/patterns.test.ts
+++ b/src/__tests__/patterns.test.ts
@@ -230,7 +230,11 @@ describe('Default Patterns', () => {
     )!;
 
     it('should match valid Ontario drivers licenses', () => {
-      const validLicenses = ['A1234-56789-01234', 'B56781234567890'];
+      const validLicenses = [
+        'A1234-56789-01234',
+        'B56781234567890',
+        'A1234 56789 01234',
+      ];
 
       validLicenses.forEach(license => {
         expect(ontarioLicensePattern.regex.test(license)).toBe(true);
@@ -258,7 +262,11 @@ describe('Default Patterns', () => {
     )!;
 
     it('should match valid Quebec drivers licenses', () => {
-      const validLicenses = ['A1234-567890-01', 'B567812345602'];
+      const validLicenses = [
+        'A1234-567890-01',
+        'B567812345602',
+        'A1234 567890 01',
+      ];
 
       validLicenses.forEach(license => {
         expect(quebecLicensePattern.regex.test(license)).toBe(true);

--- a/src/__tests__/patterns.test.ts
+++ b/src/__tests__/patterns.test.ts
@@ -70,6 +70,7 @@ describe('Default Patterns', () => {
         '012345678',
         '12345678',
         '123-456-789',
+        '123 456 789',
       ];
 
       validPRIs.forEach(pri => {
@@ -105,6 +106,7 @@ describe('Default Patterns', () => {
         '123456789',
         '987-654-321',
         '111222333',
+        '111 222 333',
       ];
 
       validSINs.forEach(sin => {

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -14,12 +14,12 @@ export const defaultPatterns: PiiPattern[] = [
   },
   {
     name: 'drivers_license_ontario',
-    regex: /\b[A-Z]\d{4}-?\d{5}-?\d{5}\b/gi,
+    regex: /\b[A-Z]\d{4}[\s-]?\d{5}[\s-]?\d{5}\b/gi,
     description: 'Ontario drivers license',
   },
   {
     name: 'drivers_license_quebec',
-    regex: /\b[A-Z]\d{4}-?\d{6}-?\d{2}\b/gi,
+    regex: /\b[A-Z]\d{4}[\s-]?\d{6}[\s-]?\d{2}\b/gi,
     description: 'Quebec drivers license',
   },
   {

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -40,12 +40,12 @@ export const defaultPatterns: PiiPattern[] = [
   },
   {
     name: 'sin',
-    regex: /\b\d{3}-?\d{3}-?\d{3}\b/g,
+    regex: /\b\d{3}[\s-]?\d{3}[\s-]?\d{3}\b/g,
     description: 'Social Insurance Number',
   },
   {
     name: 'pri',
-    regex: /\b\d{2,3}-?\d{3}-?\d{3}\b/g,
+    regex: /\b\d{2,3}[\s-]?\d{3}[\s-]?\d{3}\b/g,
     description: 'Personal Record Identifier',
   },
 ];


### PR DESCRIPTION
# Summary
Update the `pri`,  `sin` and `drivers_license` patterns so that spaces used as delimiters are also caught.

# Related
- https://github.com/cds-snc/platform-core-services/issues/781