### PR TITLE
feat: add new PII patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sanitize PII
 
-TypeScript module for removing personally identifiable information (PII) from text. 
+TypeScript module for removing personally identifiable information (PII) from text.  The PII this module removes by default can be seen in [`src/patterns.ts`](./src/patterns.ts).
 
 ## Installation
 

--- a/src/__tests__/patterns.test.ts
+++ b/src/__tests__/patterns.test.ts
@@ -134,8 +134,8 @@ describe('Default Patterns', () => {
     });
   });
 
-  describe('address pattern', () => {
-    const addressPattern = defaultPatterns.find(p => p.name === 'address')!;
+  describe('address_en pattern', () => {
+    const addressPattern = defaultPatterns.find(p => p.name === 'address_en')!;
 
     it('should match valid addresses', () => {
       const validAddresses = [
@@ -167,9 +167,43 @@ describe('Default Patterns', () => {
       });
     });
   });
+
+  describe('address_fr pattern', () => {
+    const addressPattern = defaultPatterns.find(p => p.name === 'address_fr')!;
+
+    it('should match valid French addresses', () => {
+      const validAddresses = [
+        '123 Rue de la Paix',
+        '456 Avenue des Champs-Élysées',
+        '789 Boulevard Saint-Germain',
+        '101 Chemin du Moulin',
+        '202 Allée des Fleurs',
+      ];
+
+      validAddresses.forEach(address => {
+        expect(addressPattern.regex.test(address)).toBe(true);
+        addressPattern.regex.lastIndex = 0;
+      });
+    });
+
+    it('should not match invalid French addresses', () => {
+      const invalidAddresses = [
+        'Rue de la Paix 123',
+        '456 Avenue',
+        'Boulevard Saint-Germain 789',
+        'Chemin du Moulin',
+      ];
+
+      invalidAddresses.forEach(address => {
+        expect(addressPattern.regex.test(address)).toBe(false);
+        addressPattern.regex.lastIndex = 0;
+      });
+    });
+  });
+
   describe('passport pattern', () => {
     const passportPattern = defaultPatterns.find(
-      p => p.name === 'canadian_passport'
+      p => p.name === 'passport_canada'
     )!;
 
     it('should match valid Canadian passport numbers', () => {

--- a/src/__tests__/patterns.test.ts
+++ b/src/__tests__/patterns.test.ts
@@ -322,6 +322,120 @@ describe('Default Patterns', () => {
     });
   });
 
+  describe('health_card_ontario pattern', () => {
+    const ontarioHealthCardPattern = defaultPatterns.find(
+      p => p.name === 'health_card_ontario'
+    )!;
+
+    it('should match valid Ontario health cards', () => {
+      const validCards = ['1234-567-890-AB', '1234 567 890 B', '1234567890C'];
+
+      validCards.forEach(card => {
+        expect(testFullStringMatch(ontarioHealthCardPattern.regex, card)).toBe(
+          true
+        );
+      });
+    });
+
+    it('should not match invalid Ontario health cards', () => {
+      const invalidCards = ['123-456-789-A', '1234-5678-90-B', '1234567890ADD'];
+
+      invalidCards.forEach(card => {
+        expect(ontarioHealthCardPattern.regex.test(card)).toBe(false);
+        ontarioHealthCardPattern.regex.lastIndex = 0;
+      });
+    });
+  });
+
+  describe('health_card_quebec pattern', () => {
+    const quebecHealthCardPattern = defaultPatterns.find(
+      p => p.name === 'health_card_quebec'
+    )!;
+
+    it('should match valid Quebec health cards', () => {
+      const validCards = ['ABCD-1234-5678', 'EFGH 1234 5678', 'IJKL12345678'];
+
+      validCards.forEach(card => {
+        expect(testFullStringMatch(quebecHealthCardPattern.regex, card)).toBe(
+          true
+        );
+      });
+    });
+
+    it('should not match invalid Quebec health cards', () => {
+      const invalidCards = [
+        'ABCD-12345-678',
+        'EFGH 12345 678',
+        'IJKL123456789',
+      ];
+
+      invalidCards.forEach(card => {
+        expect(quebecHealthCardPattern.regex.test(card)).toBe(false);
+        quebecHealthCardPattern.regex.lastIndex = 0;
+      });
+    });
+  });
+
+  describe('credit_card pattern', () => {
+    const creditCardPattern = defaultPatterns.find(
+      p => p.name === 'credit_card'
+    )!;
+
+    it('should match valid credit card numbers', () => {
+      const validCards = [
+        '1234-5678-9012-3456',
+        '1234 5678 9012 3456',
+        '1234567890123456',
+        '1234-5678-9012-345',
+      ];
+      validCards.forEach(card => {
+        expect(testFullStringMatch(creditCardPattern.regex, card)).toBe(true);
+      });
+    });
+
+    it('should not match invalid credit card numbers', () => {
+      const invalidCards = [
+        '1234-5678-9012-34567',
+        '1234 5678 9012 34567',
+        'asdfghjklqwerty',
+        '1234-5678-9012-34',
+      ];
+      invalidCards.forEach(card => {
+        expect(creditCardPattern.regex.test(card)).toBe(false);
+        creditCardPattern.regex.lastIndex = 0;
+      });
+    });
+  });
+
+  describe('7+_digit_number pattern', () => {
+    const sevenDigitPattern = defaultPatterns.find(
+      p => p.name === '7+_digit_number'
+    )!;
+
+    it('should match numbers with 7 or more digits', () => {
+      const validNumbers = [
+        '1234567',
+        '12345678',
+        '1234567890',
+        '9876543210',
+        '1234567890123',
+      ];
+
+      validNumbers.forEach(num => {
+        expect(testFullStringMatch(sevenDigitPattern.regex, num)).toBe(true);
+      });
+    });
+
+    it('should not match numbers with less than 7 digits', () => {
+      const invalidNumbers = ['123456', '12345', '1234', '123'];
+
+      invalidNumbers.forEach(num => {
+        expect(sevenDigitPattern.regex.test(num)).toBe(false);
+        sevenDigitPattern.regex.lastIndex = 0;
+      });
+    });
+  });
+
   it('should have all required properties', () => {
     defaultPatterns.forEach(pattern => {
       expect(pattern.name).toBeDefined();

--- a/src/__tests__/patterns.test.ts
+++ b/src/__tests__/patterns.test.ts
@@ -1,5 +1,10 @@
 import { defaultPatterns } from '../patterns';
 
+const testFullStringMatch = (regex: RegExp, text: string): boolean => {
+  const anchoredRegex = new RegExp(`^${regex.source}$`, regex.flags);
+  return anchoredRegex.test(text);
+};
+
 describe('Default Patterns', () => {
   describe('phone_number pattern', () => {
     const phonePattern = defaultPatterns.find(p => p.name === 'phone_number')!;
@@ -16,8 +21,7 @@ describe('Default Patterns', () => {
       ];
 
       validPhones.forEach(phone => {
-        expect(phonePattern.regex.test(phone)).toBe(true);
-        phonePattern.regex.lastIndex = 0;
+        expect(testFullStringMatch(phonePattern.regex, phone)).toBe(true);
       });
     });
 
@@ -45,8 +49,7 @@ describe('Default Patterns', () => {
       ];
 
       validPostalCodes.forEach(code => {
-        expect(postalPattern.regex.test(code)).toBe(true);
-        postalPattern.regex.lastIndex = 0;
+        expect(testFullStringMatch(postalPattern.regex, code)).toBe(true);
       });
     });
 
@@ -74,8 +77,7 @@ describe('Default Patterns', () => {
       ];
 
       validPRIs.forEach(pri => {
-        expect(priPattern.regex.test(pri)).toBe(true);
-        priPattern.regex.lastIndex = 0;
+        expect(testFullStringMatch(priPattern.regex, pri)).toBe(true);
       });
     });
 
@@ -110,8 +112,7 @@ describe('Default Patterns', () => {
       ];
 
       validSINs.forEach(sin => {
-        expect(sinPattern.regex.test(sin)).toBe(true);
-        sinPattern.regex.lastIndex = 0;
+        expect(testFullStringMatch(sinPattern.regex, sin)).toBe(true);
       });
     });
 
@@ -140,16 +141,15 @@ describe('Default Patterns', () => {
     it('should match valid addresses', () => {
       const validAddresses = [
         '123 Main St',
-        '456 Elm Avenue.',
+        '456 Elm Avenue',
         '789 Maple Road',
         '101 Pine Boulevard',
         '202 Oak Drive',
-        '#45-303 Cedar Prv.',
+        '45-303 Cedar Prv',
       ];
 
       validAddresses.forEach(address => {
-        expect(addressPattern.regex.test(address)).toBe(true);
-        addressPattern.regex.lastIndex = 0;
+        expect(testFullStringMatch(addressPattern.regex, address)).toBe(true);
       });
     });
 
@@ -178,11 +178,11 @@ describe('Default Patterns', () => {
         '789 Boulevard Saint-Germain',
         '101 Chemin du Moulin',
         '202 Allée des Fleurs',
+        "4520-303 Impasse d'Orléans",
       ];
 
       validAddresses.forEach(address => {
-        expect(addressPattern.regex.test(address)).toBe(true);
-        addressPattern.regex.lastIndex = 0;
+        expect(testFullStringMatch(addressPattern.regex, address)).toBe(true);
       });
     });
 
@@ -210,8 +210,7 @@ describe('Default Patterns', () => {
       const validPassports = ['AB123456', 'CD 123456', 'EF-123456', 'GH123456'];
 
       validPassports.forEach(passport => {
-        expect(passportPattern.regex.test(passport)).toBe(true);
-        passportPattern.regex.lastIndex = 0;
+        expect(testFullStringMatch(passportPattern.regex, passport)).toBe(true);
       });
     });
 
@@ -243,8 +242,7 @@ describe('Default Patterns', () => {
       ];
 
       validIPs.forEach(ip => {
-        expect(ipPattern.regex.test(ip)).toBe(true);
-        ipPattern.regex.lastIndex = 0;
+        expect(testFullStringMatch(ipPattern.regex, ip)).toBe(true);
       });
     });
 
@@ -271,8 +269,9 @@ describe('Default Patterns', () => {
       ];
 
       validLicenses.forEach(license => {
-        expect(ontarioLicensePattern.regex.test(license)).toBe(true);
-        ontarioLicensePattern.regex.lastIndex = 0;
+        expect(testFullStringMatch(ontarioLicensePattern.regex, license)).toBe(
+          true
+        );
       });
     });
 
@@ -303,8 +302,9 @@ describe('Default Patterns', () => {
       ];
 
       validLicenses.forEach(license => {
-        expect(quebecLicensePattern.regex.test(license)).toBe(true);
-        quebecLicensePattern.regex.lastIndex = 0;
+        expect(testFullStringMatch(quebecLicensePattern.regex, license)).toBe(
+          true
+        );
       });
     });
 

--- a/src/__tests__/sanitizer.test.ts
+++ b/src/__tests__/sanitizer.test.ts
@@ -63,7 +63,7 @@ describe('PiiSanitizer', () => {
     it('should update replacement template', () => {
       sanitizer.setReplacementTemplate('REMOVED_{name}');
       const result = sanitizer.sanitize('123 Fake St');
-      expect(result).toBe('REMOVED_address');
+      expect(result).toBe('REMOVED_address_en');
     });
   });
 
@@ -79,9 +79,11 @@ describe('PiiSanitizer', () => {
     });
 
     it('should sanitize home addresses', () => {
-      const text = 'Contact me at 123 Fake St for more info';
+      const text = 'Contact me at 123 Fake St or 34 rue Bernard for more info';
       const result = sanitizer.sanitize(text);
-      expect(result).toBe('Contact me at [Redacted: address] for more info');
+      expect(result).toBe(
+        'Contact me at [Redacted: address_en] or [Redacted: address_fr] for more info'
+      );
     });
 
     it('should sanitize multiple phone numbers', () => {
@@ -126,7 +128,7 @@ describe('PiiSanitizer', () => {
         'Call me at (555) 123-4567. My postal code is K1A 0A6 and I live at 123 Main St., Ottawa.';
       const result = sanitizer.sanitize(text);
       expect(result).toBe(
-        'Call me at [Redacted: phone_number]. My postal code is [Redacted: postal_code] and I live at [Redacted: address]., Ottawa.'
+        'Call me at [Redacted: phone_number]. My postal code is [Redacted: postal_code] and I live at [Redacted: address_en]., Ottawa.'
       );
     });
 
@@ -145,7 +147,7 @@ describe('PiiSanitizer', () => {
 
     it('should detect home addresses', () => {
       const result = sanitizer.detectPii('Contact me at 123 Fake Ave');
-      expect(result).toContain('address');
+      expect(result).toContain('address_en');
     });
 
     it('should detect multiple PII types', () => {

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -4,13 +4,13 @@ export const defaultPatterns: PiiPattern[] = [
   {
     name: 'address_en',
     regex:
-      /\b[\d#-]+[\s-]+[A-Z-]+[\s-]+(?:street|st|avenue|ave|road|rd|boulevard|blvd|drive|dr|lane|ln|court|ct|place|pl|way|crescent|cres|circle|cir|parkway|pkwy|terrace|ter|square|sq|trail|trl|close|cl|grove|grv|heights|hts|hill|park|gardens|gdns|manor|mnr|estates|est|valley|vly|view|vw|point|pt|ridge|rdg|bay|cove|cv|mews|row|common|green|grn|landing|lndg|crossing|xing|glen|gln|meadow|mdw|pass|run|bend|curve|curv|fork|frk|gap|hollow|holw|knoll|knl|lock|lck|mill|ml|orchard|orch|path|pth|pine|pne|pond|shoal|shl|shore|shr|spring|spg|summit|smt|trace|trce|track|trak|turnpike|tpke|walk|wlk|woods|wds|private|prv)\.?\b/gi,
+      /\b[\d-]+[\s-]+[A-Z-]+[\s-]+(?:street|st|avenue|ave|road|rd|boulevard|blvd|drive|dr|lane|ln|court|ct|place|pl|way|crescent|cres|circle|cir|parkway|pkwy|terrace|ter|square|sq|trail|trl|close|cl|grove|grv|heights|hts|hill|park|gardens|gdns|manor|mnr|estates|est|valley|vly|view|vw|point|pt|ridge|rdg|bay|cove|cv|mews|row|common|green|grn|landing|lndg|crossing|xing|glen|gln|meadow|mdw|pass|run|bend|curve|curv|fork|frk|gap|hollow|holw|knoll|knl|lock|lck|mill|ml|orchard|orch|path|pth|pine|pne|pond|shoal|shl|shore|shr|spring|spg|summit|smt|trace|trce|track|trak|turnpike|tpke|walk|wlk|woods|wds|private|prv)\b/gi,
     description: 'Address (English)',
   },
   {
     name: 'address_fr',
     regex:
-      /\b[\d#-]+[\s-]+(?:rue|rte|avenue|av|boulevard|bd|chemin|ch|route|allée|all|place|pl|voie|v|carré|carre|impasse|imp|quai|qai|passage|pass)\.?[\s-]+(?:des|de\sla|du|d')?[\s-]?[A-ZÀÂÄÇÉÈÊËÎÏÔÖÙÛÜŸ-]+\b/gi,
+      /\b[\d-]+[\s-]+(?:rue|rte|avenue|av|boulevard|bd|chemin|ch|route|allée|all|place|pl|voie|v|carré|carre|impasse|imp|quai|qai|passage|pass)\.?[\s-]+(?:des|de\sla|du|d')?[\s-]?[A-ZÀÂÄÇÉÈÊËÎÏÔÖÙÛÜŸ-]+\b/gi,
     description: 'Address (French)',
   },
   {

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -2,13 +2,19 @@ import { PiiPattern } from './types.js';
 
 export const defaultPatterns: PiiPattern[] = [
   {
-    name: 'address',
+    name: 'address_en',
     regex:
-      /\b[\d#-]+[\s-]+[A-Z\s-]+(?:street|st|avenue|ave|road|rd|boulevard|blvd|drive|dr|lane|ln|court|ct|place|pl|way|crescent|cres|circle|cir|parkway|pkwy|terrace|ter|square|sq|trail|trl|close|cl|grove|grv|heights|hts|hill|park|gardens|gdns|manor|mnr|estates|est|valley|vly|view|vw|point|pt|ridge|rdg|bay|cove|cv|mews|row|common|green|grn|landing|lndg|crossing|xing|glen|gln|meadow|mdw|pass|run|bend|curve|curv|fork|frk|gap|hollow|holw|knoll|knl|lock|lck|mill|ml|orchard|orch|path|pth|pine|pne|pond|shoal|shl|shore|shr|spring|spg|summit|smt|trace|trce|track|trak|turnpike|tpke|walk|wlk|woods|wds|private|prv)\.?\b/gi,
-    description: 'Address',
+      /\b[\d#-]+[\s-]+[A-Z-]+[\s-]+(?:street|st|avenue|ave|road|rd|boulevard|blvd|drive|dr|lane|ln|court|ct|place|pl|way|crescent|cres|circle|cir|parkway|pkwy|terrace|ter|square|sq|trail|trl|close|cl|grove|grv|heights|hts|hill|park|gardens|gdns|manor|mnr|estates|est|valley|vly|view|vw|point|pt|ridge|rdg|bay|cove|cv|mews|row|common|green|grn|landing|lndg|crossing|xing|glen|gln|meadow|mdw|pass|run|bend|curve|curv|fork|frk|gap|hollow|holw|knoll|knl|lock|lck|mill|ml|orchard|orch|path|pth|pine|pne|pond|shoal|shl|shore|shr|spring|spg|summit|smt|trace|trce|track|trak|turnpike|tpke|walk|wlk|woods|wds|private|prv)\.?\b/gi,
+    description: 'Address (English)',
   },
   {
-    name: 'canadian_passport',
+    name: 'address_fr',
+    regex:
+      /\b[\d#-]+[\s-]+(?:rue|rte|avenue|av|boulevard|bd|chemin|ch|route|allée|all|place|pl|voie|v|carré|carre|impasse|imp|quai|qai|passage|pass)\.?[\s-]+(?:des|de\sla|du)?[\s-]?[A-Z-]+\b/gi,
+    description: 'Address (French)',
+  },
+  {
+    name: 'passport_canada',
     regex: /\b([A-Z]{2}[\s-]?\d{6})\b/g,
     description: 'Canadian passport',
   },

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -14,9 +14,9 @@ export const defaultPatterns: PiiPattern[] = [
     description: 'Address (French)',
   },
   {
-    name: 'passport_canada',
-    regex: /\b([A-Z]{2}[\s-]?\d{6})\b/g,
-    description: 'Canadian passport',
+    name: 'credit_card',
+    regex: /\b(?:\d{4}[\s-]?){3}\d{3,4}\b/g,
+    description: 'Credit card number',
   },
   {
     name: 'drivers_license_ontario',
@@ -29,9 +29,24 @@ export const defaultPatterns: PiiPattern[] = [
     description: 'Quebec drivers license',
   },
   {
+    name: 'health_card_ontario',
+    regex: /\b\d{4}[\s-]?\d{3}[\s-]?\d{3}[\s-]?[A-Z]{1,2}\b/g,
+    description: 'Ontario health card',
+  },
+  {
+    name: 'health_card_quebec',
+    regex: /\b[A-Z]{4}[\s-]?\d{4}[\s-]?\d{4}\b/g,
+    description: 'Quebec health card',
+  },
+  {
     name: 'ip_address',
     regex: /\b(?:\d{1,3}\.){3}\d{1,3}\b/g,
     description: 'IP address',
+  },
+  {
+    name: 'passport_canada',
+    regex: /\b([A-Z]{2}[\s-]?\d{6})\b/g,
+    description: 'Canadian passport',
   },
   {
     name: 'phone_number',
@@ -53,5 +68,10 @@ export const defaultPatterns: PiiPattern[] = [
     name: 'pri',
     regex: /\b\d{2,3}[\s-]?\d{3}[\s-]?\d{3}\b/g,
     description: 'Personal Record Identifier',
+  },
+  {
+    name: '7+_digit_number', // Catches provincial driver's license and health card numbers
+    regex: /\b\d{7,}\b/g,
+    description: '7 or more digit number',
   },
 ];

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -10,7 +10,7 @@ export const defaultPatterns: PiiPattern[] = [
   {
     name: 'address_fr',
     regex:
-      /\b[\d#-]+[\s-]+(?:rue|rte|avenue|av|boulevard|bd|chemin|ch|route|allée|all|place|pl|voie|v|carré|carre|impasse|imp|quai|qai|passage|pass)\.?[\s-]+(?:des|de\sla|du)?[\s-]?[A-ZÀÂÄÇÉÈÊËÎÏÔÖÙÛÜŸ-]+\b/gi,
+      /\b[\d#-]+[\s-]+(?:rue|rte|avenue|av|boulevard|bd|chemin|ch|route|allée|all|place|pl|voie|v|carré|carre|impasse|imp|quai|qai|passage|pass)\.?[\s-]+(?:des|de\sla|du|d')?[\s-]?[A-ZÀÂÄÇÉÈÊËÎÏÔÖÙÛÜŸ-]+\b/gi,
     description: 'Address (French)',
   },
   {

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -10,7 +10,7 @@ export const defaultPatterns: PiiPattern[] = [
   {
     name: 'address_fr',
     regex:
-      /\b[\d#-]+[\s-]+(?:rue|rte|avenue|av|boulevard|bd|chemin|ch|route|allée|all|place|pl|voie|v|carré|carre|impasse|imp|quai|qai|passage|pass)\.?[\s-]+(?:des|de\sla|du)?[\s-]?[A-Z-]+\b/gi,
+      /\b[\d#-]+[\s-]+(?:rue|rte|avenue|av|boulevard|bd|chemin|ch|route|allée|all|place|pl|voie|v|carré|carre|impasse|imp|quai|qai|passage|pass)\.?[\s-]+(?:des|de\sla|du)?[\s-]?[A-ZÀÂÄÇÉÈÊËÎÏÔÖÙÛÜŸ-]+\b/gi,
     description: 'Address (French)',
   },
   {


### PR DESCRIPTION
# Summary
Add the following new PII patterns:
- Address (French format)
- Credit card
- Health card (Ontario/Quebec)
- 7+ digit number (matches many provincial driver's licenses and health cards)

# Related
- https://github.com/cds-snc/platform-core-services/issues/781