### PR TITLE
fix: set the registry-url in npm publish workflow

### DIFF
--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           node-version: 24
           cache: npm
+          registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
# Summary
Update the setup-node action to set the npmjs registry URL so that the NODE_AUTH_TOKEN is properly used for authentication.

# Related
- https://github.com/cds-snc/platform-core-services/issues/781