### PR TITLE
feat: add pattern for GC Notify API key

### DIFF
--- a/src/__tests__/patterns.test.ts
+++ b/src/__tests__/patterns.test.ts
@@ -436,6 +436,36 @@ describe('Default Patterns', () => {
     });
   });
 
+  describe('api_key_gc_notify pattern', () => {
+    const apiKeyPattern = defaultPatterns.find(
+      p => p.name === 'api_key_gc_notify'
+    )!;
+
+    it('should match valid GC Notify API keys', () => {
+      const validKeys = [
+        'gcntfy-test-e2253c4f-b642-4ef5-a104-f3d823bb2158',
+        'gcntfy-another-name-9e8cada6-6f29-4afb-866c-3d696b60735e',
+        'gcntfy-some-key-name-ae6dd110-78b4-49a0-94b8-748121735882',
+      ];
+      validKeys.forEach(key => {
+        expect(testFullStringMatch(apiKeyPattern.regex, key)).toBe(true);
+      });
+    });
+
+    it('should not match invalid GC Notify API keys', () => {
+      const invalidKeys = [
+        'muffins-gcnotify',
+        'gcntfy-abcdefg',
+        'gcntfy-1234-5678-90ab-cdefg',
+        'notgcntfy-e2253c4f-b642-4ef5-a104-f3d823bb2158',
+      ];
+      invalidKeys.forEach(key => {
+        expect(apiKeyPattern.regex.test(key)).toBe(false);
+        apiKeyPattern.regex.lastIndex = 0;
+      });
+    });
+  });
+
   it('should have all required properties', () => {
     defaultPatterns.forEach(pattern => {
       expect(pattern.name).toBeDefined();

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -14,6 +14,12 @@ export const defaultPatterns: PiiPattern[] = [
     description: 'Address (French)',
   },
   {
+    name: 'api_key_gc_notify',
+    regex:
+      /\bgcntfy-[A-Z0-9-]+[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\b/gi,
+    description: 'API key (GC Notify)',
+  },
+  {
     name: 'credit_card',
     regex: /\b(?:\d{4}[\s-]?){3}\d{3,4}\b/g,
     description: 'Credit card number',


### PR DESCRIPTION
# Summary
Add a pattern to redact GC Notify API keys.

# Related
- https://github.com/cds-snc/platform-core-services/issues/781