### PR TITLE
fix: catch Notify API key with underscores

### DIFF
--- a/src/__tests__/patterns.test.ts
+++ b/src/__tests__/patterns.test.ts
@@ -770,6 +770,7 @@ describe('Default Patterns', () => {
     it('should match valid GC Notify API keys', () => {
       const validKeys = [
         'gcntfy-test-e2253c4f-b642-4ef5-a104-f3d823bb2158',
+        'gcntfy-test_underscores_pattern-e2253c4f-b642-4ef5-a104-f3d823bb2158',
         'gcntfy-another-name-9e8cada6-6f29-4afb-866c-3d696b60735e',
         'gcntfy-some-key-name-ae6dd110-78b4-49a0-94b8-748121735882',
       ];
@@ -783,6 +784,7 @@ describe('Default Patterns', () => {
         'muffins-gcnotify',
         'gcntfy-abcdefg',
         'gcntfy-1234-5678-90ab-cdefg',
+        'gcntfy-nogap9e8cada6-6f29-4afb-866c-3d696b60735e',
         'notgcntfy-e2253c4f-b642-4ef5-a104-f3d823bb2158',
       ];
       invalidKeys.forEach(key => {

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -16,7 +16,7 @@ export const defaultPatterns: PiiPattern[] = [
   {
     name: 'api_key_gc_notify',
     regex:
-      /\bgcntfy-[A-Z0-9-]+[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\b/gi,
+      /\bgcntfy-[A-Z0-9-_]+-[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\b/gi,
     description: 'API key (GC Notify)',
   },
   {


### PR DESCRIPTION
# Summary
Add underscores to the Notify API key pattern.

# Related
- https://github.com/cds-snc/platform-core-services/issues/781