### PR TITLE
fix: prevent phone number from matching timestamp

### DIFF
--- a/src/__tests__/patterns.test.ts
+++ b/src/__tests__/patterns.test.ts
@@ -27,7 +27,14 @@ describe('Default Patterns', () => {
     });
 
     it('should not match invalid phone numbers', () => {
-      const invalidPhones = ['123-456-789', '555-123-45678', 'abc-def-ghij'];
+      const invalidPhones = [
+        '123-456-789',
+        '555-123-45678',
+        'abc-def-ghij',
+        'FR01-1756211151235',
+        '-1-555_123_4567',
+        'asdf5551234567',
+      ];
 
       invalidPhones.forEach(phone => {
         expect(phonePattern.regex.test(phone)).toBe(false);

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -102,7 +102,7 @@ export const defaultPatterns: PiiPattern[] = [
   {
     name: 'phone_number',
     regex:
-      /(?:\+?1[-_.\s]?)?\(?([0-9]{3})\)?[-_.\s]?([0-9]{3})[-_.\s]?([0-9]{4})\b/g,
+      /(?<![\w-])(?:\+?1[-_.\s]?)?\(?([0-9]{3})\)?[-_.\s]?([0-9]{3})[-_.\s]?([0-9]{4})\b/g,
     description: 'North American phone number',
   },
   {


### PR DESCRIPTION
# Summary
Add a negative lookbehind to the phone number pattern to make sure the match is not preceeded by a word character (letter, number, underscore) or dash.  This prevents it from matching the end of timestamps.

The `\b` word boundary meta character cannot be used here because some phone numbers will start with a "(" for the area code.

# Related
- https://github.com/cds-snc/platform-core-services/issues/809